### PR TITLE
ux: 4 melhorias de UX — recuperar senha, perfil e botões sem ação

### DIFF
--- a/app/(auth)/recuperar/page.tsx
+++ b/app/(auth)/recuperar/page.tsx
@@ -14,25 +14,49 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { MailCheck } from 'lucide-react'
 
 export default function RecuperarPage() {
   const [email, setEmail] = useState('')
   const [sending, setSending] = useState(false)
-  const [msg, setMsg] = useState<string | null>(null)
+  const [sent, setSent] = useState(false)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setSending(true)
-    setMsg(null)
 
     try {
       await api.post('/auth/forgot-password', { email })
     } catch {
       // resposta deliberadamente ambígua — não revela se o e-mail existe
     } finally {
-      setMsg('Se este e-mail estiver cadastrado, você receberá um link para redefinir a senha.')
       setSending(false)
+      setSent(true)
     }
+  }
+
+  if (sent) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <Card className="w-full max-w-md card">
+          <CardHeader className="text-center">
+            <div className="flex justify-center mb-2">
+              <MailCheck className="h-10 w-10 text-primary" />
+            </div>
+            <CardTitle className="text-2xl">Verifique seu e-mail</CardTitle>
+            <CardDescription>
+              Se <strong>{email}</strong> estiver cadastrado, você receberá um link
+              de redefinição em breve. Verifique também a pasta de spam.
+            </CardDescription>
+          </CardHeader>
+          <CardFooter className="flex justify-center text-sm">
+            <Link href="/login" className="text-primary hover:underline">
+              Voltar para o login
+            </Link>
+          </CardFooter>
+        </Card>
+      </div>
+    )
   }
 
   return (
@@ -57,12 +81,6 @@ export default function RecuperarPage() {
                 disabled={sending}
               />
             </div>
-
-            {msg && (
-              <p className="text-sm text-center text-muted-foreground" aria-live="polite">
-                {msg}
-              </p>
-            )}
 
             <Button type="submit" className="w-full" disabled={sending}>
               {sending ? 'Enviando...' : 'Enviar link de recuperação'}

--- a/app/(dashboard)/perfil/page.tsx
+++ b/app/(dashboard)/perfil/page.tsx
@@ -10,14 +10,12 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Separator } from '@/components/ui/separator'
-import { Switch } from '@/components/ui/switch'
 import {
   User as UserIcon,
   Calendar, Edit, Save, X, Loader2,
-  Shield, Bell, Lock, Trash2, Download,
+  Shield, Lock, Trash2, Download,
   BarChart3, Award, Clock, CheckCircle2,
 } from 'lucide-react'
 
@@ -94,12 +92,6 @@ export default function PerfilPage() {
   const [error, setError] = useState<string | null>(null)
 
   const [formData, setFormData] = useState({ nome: '', email: '', telefone: '' })
-
-  const [configuracoes, setConfiguracoes] = useState({
-    notificacoesPush: true,
-    notificacoesEmail: true,
-    visibilidadePerfil: 'publico' as string,
-  })
 
   useEffect(() => {
     const fetchAll = async () => {
@@ -294,65 +286,6 @@ export default function PerfilPage() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Bell className="h-5 w-5" />
-                Configurações
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="grid gap-6">
-                <div>
-                  <h4 className="font-medium mb-3">Notificações</h4>
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">Notificações Push</p>
-                        <p className="text-sm text-muted-foreground">Receba notificações no navegador</p>
-                      </div>
-                      <Switch
-                        checked={configuracoes.notificacoesPush}
-                        onCheckedChange={(checked) => setConfiguracoes((p) => ({ ...p, notificacoesPush: checked }))}
-                      />
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">Notificações por Email</p>
-                        <p className="text-sm text-muted-foreground">Receba resumos por email</p>
-                      </div>
-                      <Switch
-                        checked={configuracoes.notificacoesEmail}
-                        onCheckedChange={(checked) => setConfiguracoes((p) => ({ ...p, notificacoesEmail: checked }))}
-                      />
-                    </div>
-                  </div>
-                </div>
-
-                <Separator />
-
-                <div>
-                  <h4 className="font-medium mb-3">Privacidade</h4>
-                  <div>
-                    <Label>Visibilidade do Perfil</Label>
-                    <Select
-                      value={configuracoes.visibilidadePerfil}
-                      onValueChange={(value) => setConfiguracoes((p) => ({ ...p, visibilidadePerfil: value }))}
-                    >
-                      <SelectTrigger className="mt-1">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="publico">Público</SelectItem>
-                        <SelectItem value="privado">Privado</SelectItem>
-                        <SelectItem value="equipe">Apenas Equipe</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
         </div>
 
         <div className="space-y-6">

--- a/app/(dashboard)/perfil/page.tsx
+++ b/app/(dashboard)/perfil/page.tsx
@@ -336,14 +336,16 @@ export default function PerfilPage() {
                   Alterar Senha
                 </a>
               </Button>
-              <Button variant="outline" className="w-full justify-start">
+              <Button variant="outline" className="w-full justify-start" disabled>
                 <Download className="h-4 w-4 mr-2" />
                 Exportar Dados
+                <span className="ml-auto text-xs text-muted-foreground">em breve</span>
               </Button>
               <Separator />
-              <Button variant="destructive" className="w-full justify-start">
+              <Button variant="outline" className="w-full justify-start text-destructive hover:text-destructive" disabled>
                 <Trash2 className="h-4 w-4 mr-2" />
                 Excluir Conta
+                <span className="ml-auto text-xs text-muted-foreground">em breve</span>
               </Button>
             </CardContent>
           </Card>

--- a/app/(dashboard)/perfil/page.tsx
+++ b/app/(dashboard)/perfil/page.tsx
@@ -228,12 +228,19 @@ export default function PerfilPage() {
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="flex items-center gap-6">
-                <Avatar className="w-24 h-24">
-                  <AvatarImage src={usuario.avatar || undefined} alt={usuario.nome} />
-                  <AvatarFallback className="text-lg font-semibold">
-                    {getInitials(usuario.nome)}
-                  </AvatarFallback>
-                </Avatar>
+                <div className="relative">
+                  <Avatar className="w-24 h-24">
+                    <AvatarImage src={usuario.avatar || undefined} alt={usuario.nome} />
+                    <AvatarFallback className="text-lg font-semibold">
+                      {getInitials(usuario.nome)}
+                    </AvatarFallback>
+                  </Avatar>
+                  {editMode && (
+                    <span className="absolute -bottom-5 left-1/2 -translate-x-1/2 whitespace-nowrap text-xs text-muted-foreground">
+                      upload em breve
+                    </span>
+                  )}
+                </div>
                 <div className="space-y-1">
                   <h2 className="text-xl font-semibold">{usuario.nome}</h2>
                   <p className="text-muted-foreground">{usuario.email}</p>


### PR DESCRIPTION
Quatro ajustes de UX, um commit cada.

---

### 1 — `/recuperar`: tela de confirmação após envio

**Antes:** o form continuava visível com a mensagem de sucesso embaixo — o usuário podia continuar digitando sem propósito.

**Depois:** ao clicar em "Enviar", o form é substituído por uma tela com ícone `MailCheck`, mostrando o e-mail usado e instrução para checar spam.

---

### 2 — Perfil: card "Configurações" removido

Os toggles de notificação e o select de privacidade salvavam apenas em estado React local — eram descartados a cada reload. Um controle que parece persistir mas não persiste é pior do que não ter controle. Card removido até existir backend para suportá-los.

---

### 3 — Perfil: botões "Exportar Dados" e "Excluir Conta" desabilitados

Ambos existiam sem `onClick`. "Excluir Conta" tinha visual destrutivo (vermelho), o que cria ansiedade em quem clica e não acontece nada. Agora aparecem desabilitados com label "em breve" à direita.

---

### 4 — Perfil: hint de avatar no modo edição

O upload de avatar foi removido quando Supabase Storage saiu. Em modo de edição, o avatar exibe um texto "upload em breve" abaixo para deixar claro que a feature é planejada, não quebrada.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdRDDdiaAhDYXHupLTaDJE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdRDDdiaAhDYXHupLTaDJE)_