### PR TITLE
feat: email verification flow

### DIFF
--- a/app/(auth)/cadastro/page.tsx
+++ b/app/(auth)/cadastro/page.tsx
@@ -391,8 +391,7 @@ export default function CadastroPage() {
         tipo: tipo ?? 'DESIGNER',
       });
 
-      await signIn(email, password);
-      router.replace('/dashboard');
+      router.replace('/verificar-email');
     } catch (err: any) {
       setMsg(err?.message ?? 'Erro inesperado ao cadastrar.');
     } finally {

--- a/app/(auth)/verificar-email/page.tsx
+++ b/app/(auth)/verificar-email/page.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState, useEffect, Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { api } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import {
+  Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { MailCheck, MailX, Loader2, Mail } from 'lucide-react'
+
+type Status = 'idle' | 'verifying' | 'success' | 'error'
+
+function VerificarEmailContent() {
+  const search = useSearchParams()
+  const token = search.get('token')
+
+  const [status, setStatus] = useState<Status>(token ? 'verifying' : 'idle')
+  const [errorMsg, setErrorMsg] = useState('')
+
+  // Resend form
+  const [email, setEmail] = useState('')
+  const [resending, setResending] = useState(false)
+  const [resent, setResent] = useState(false)
+
+  useEffect(() => {
+    if (!token) return
+
+    api.get<{ success: boolean }>(`/auth/verify-email?token=${encodeURIComponent(token)}`)
+      .then(() => setStatus('success'))
+      .catch((err: any) => {
+        setErrorMsg(err?.message ?? 'Link inválido ou expirado.')
+        setStatus('error')
+      })
+  }, [token])
+
+  const handleResend = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setResending(true)
+    try {
+      await api.post('/auth/resend-verification', { email })
+    } catch {
+      // anti-enumeração — sempre a mesma resposta
+    } finally {
+      setResending(false)
+      setResent(true)
+    }
+  }
+
+  // Verificando token...
+  if (status === 'verifying') {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <Card className="w-full max-w-md card">
+          <CardHeader className="text-center">
+            <div className="flex justify-center mb-2">
+              <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
+            </div>
+            <CardTitle className="text-2xl">Verificando...</CardTitle>
+            <CardDescription>Aguarde enquanto confirmamos seu e-mail.</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+
+  // Verificado com sucesso
+  if (status === 'success') {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <Card className="w-full max-w-md card">
+          <CardHeader className="text-center">
+            <div className="flex justify-center mb-2">
+              <MailCheck className="h-10 w-10 text-primary" />
+            </div>
+            <CardTitle className="text-2xl">E-mail confirmado!</CardTitle>
+            <CardDescription>
+              Sua conta está ativa. Faça login para começar a usar o VIU.
+            </CardDescription>
+          </CardHeader>
+          <CardFooter className="flex justify-center">
+            <Button asChild>
+              <Link href="/login">Fazer login</Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    )
+  }
+
+  // Token inválido / expirado
+  if (status === 'error') {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <Card className="w-full max-w-md card">
+          <CardHeader className="text-center">
+            <div className="flex justify-center mb-2">
+              <MailX className="h-10 w-10 text-destructive" />
+            </div>
+            <CardTitle className="text-2xl">Link inválido</CardTitle>
+            <CardDescription>{errorMsg} Solicite um novo link abaixo.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {resent ? (
+              <p className="text-sm text-center text-muted-foreground">
+                Se o e-mail estiver pendente de verificação, você receberá um novo link em breve.
+              </p>
+            ) : (
+              <form onSubmit={handleResend} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="email">Seu e-mail</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="seu@email.com"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    disabled={resending}
+                  />
+                </div>
+                <Button type="submit" className="w-full" disabled={resending}>
+                  {resending ? 'Enviando...' : 'Reenviar link de verificação'}
+                </Button>
+              </form>
+            )}
+          </CardContent>
+          <CardFooter className="flex justify-center text-sm">
+            <Link href="/login" className="text-muted-foreground hover:underline">
+              Voltar para o login
+            </Link>
+          </CardFooter>
+        </Card>
+      </div>
+    )
+  }
+
+  // Sem token — mostrado após o cadastro
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <Card className="w-full max-w-md card">
+        <CardHeader className="text-center">
+          <div className="flex justify-center mb-2">
+            <Mail className="h-10 w-10 text-primary" />
+          </div>
+          <CardTitle className="text-2xl">Verifique seu e-mail</CardTitle>
+          <CardDescription>
+            Enviamos um link de confirmação para o e-mail cadastrado. Clique nele para
+            ativar sua conta. Verifique também a pasta de spam.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {resent ? (
+            <p className="text-sm text-center text-muted-foreground">
+              Novo link enviado. Verifique sua caixa de entrada.
+            </p>
+          ) : (
+            <form onSubmit={handleResend} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email">Não recebeu? Reenviar para:</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="seu@email.com"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={resending}
+                />
+              </div>
+              <Button type="submit" variant="outline" className="w-full" disabled={resending}>
+                {resending ? 'Enviando...' : 'Reenviar link'}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+        <CardFooter className="flex justify-center text-sm">
+          <Link href="/login" className="text-muted-foreground hover:underline">
+            Já verificou? Fazer login
+          </Link>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+
+export default function VerificarEmailPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    }>
+      <VerificarEmailContent />
+    </Suspense>
+  )
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
-// app/(dashboard)/layout.tsx
 import { Sidebar } from '@/components/layout/Sidebar'
 import SignOutButton from '@/components/layout/SignOutButton'
+import { EmailVerificationBanner } from '@/components/layout/EmailVerificationBanner'
 
 export default function DashboardLayout({
   children,
@@ -11,11 +11,10 @@ export default function DashboardLayout({
     <div className="flex h-screen bg-background">
       <Sidebar />
       <main className="flex-1 overflow-auto">
-        {/* Topbar simples com o botão de sair */}
         <div className="flex items-center justify-end p-4 border-b">
           <SignOutButton />
         </div>
-
+        <EmailVerificationBanner />
         {children}
       </main>
     </div>

--- a/components/layout/EmailVerificationBanner.tsx
+++ b/components/layout/EmailVerificationBanner.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { api } from '@/lib/api'
+import { MailWarning, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function EmailVerificationBanner() {
+  const { user } = useAuth()
+  const [dismissed, setDismissed] = useState(false)
+  const [sent, setSent] = useState(false)
+  const [sending, setSending] = useState(false)
+
+  if (!user || user.emailVerificado !== false || dismissed) return null
+
+  const handleResend = async () => {
+    setSending(true)
+    try {
+      await api.post('/auth/resend-verification', { email: user.email })
+    } catch {
+      // anti-enumeração
+    } finally {
+      setSending(false)
+      setSent(true)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-4 bg-yellow-50 border-b border-yellow-200 px-4 py-2 text-sm text-yellow-800">
+      <div className="flex items-center gap-2">
+        <MailWarning className="h-4 w-4 shrink-0" />
+        {sent
+          ? 'Link de verificação reenviado. Verifique sua caixa de entrada.'
+          : 'Confirme seu e-mail para garantir acesso completo à sua conta.'}
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {!sent && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 border-yellow-400 text-yellow-800 hover:bg-yellow-100"
+            onClick={handleResend}
+            disabled={sending}
+          >
+            {sending ? 'Enviando...' : 'Reenviar e-mail'}
+          </Button>
+        )}
+        <button
+          onClick={() => setDismissed(true)}
+          className="text-yellow-600 hover:text-yellow-800"
+          aria-label="Fechar"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ export type UserProfile = {
   email: string
   avatar?: string | null
   tipo: 'DESIGNER' | 'CLIENTE'
+  emailVerificado?: boolean
 }
 
 type AuthContextType = {


### PR DESCRIPTION
## Summary

- Adds `emailVerificado?: boolean` to `UserProfile` type in `AuthContext`
- New `/verificar-email` page with four states: verifying (token in URL), success, error (with resend form), and idle (shown after registration)
- Post-registration redirect changed from auto-login to `/verificar-email`
- `EmailVerificationBanner` component shown in dashboard for users with unverified emails — dismissible, with resend button
- Banner wired into dashboard layout above page content

## Test plan

- [ ] Register a new account → redirected to `/verificar-email` with instructions
- [ ] Click "Reenviar link" on that page → success message shown
- [ ] Open verification link from email → spinner → "E-mail confirmado!" → login button
- [ ] Open expired/invalid token URL → error state with resend form
- [ ] Log in with an unverified account → yellow banner appears in dashboard
- [ ] Click "Reenviar e-mail" in banner → button replaced by success text
- [ ] Dismiss banner with X → banner disappears for the session
- [ ] Log in with a verified account → no banner shown

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdRDDdiaAhDYXHupLTaDJE)_