### PR TITLE
feat: refresh token support in API client and AuthContext

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -25,6 +25,8 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 const TOKEN_KEY = 'viu_token'
 const USER_KEY = 'viu_user'
+const REFRESH_KEY = 'viu_refresh_token'
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3333'
 
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
   try {
@@ -70,20 +72,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const signIn = useCallback(async (email: string, senha: string) => {
-    const res = await api.post<{ data: { token: string; usuario: UserProfile }; success: boolean }>(
+    const res = await api.post<{ data: { token: string; refreshToken: string; usuario: UserProfile }; success: boolean }>(
       '/auth/login',
       { email, senha }
     )
-    const { token: newToken, usuario } = res.data
+    const { token: newToken, refreshToken, usuario } = res.data
     localStorage.setItem(TOKEN_KEY, newToken)
     localStorage.setItem(USER_KEY, JSON.stringify(usuario))
+    if (refreshToken) localStorage.setItem(REFRESH_KEY, refreshToken)
     setToken(newToken)
     setUser(usuario)
   }, [])
 
   const signOut = useCallback(() => {
+    const currentToken = localStorage.getItem(TOKEN_KEY)
+    if (currentToken) {
+      fetch(`${BASE_URL}/auth/logout`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${currentToken}`, 'Content-Type': 'application/json' },
+      }).catch(() => {})
+    }
     localStorage.removeItem(TOKEN_KEY)
     localStorage.removeItem(USER_KEY)
+    localStorage.removeItem(REFRESH_KEY)
     setToken(null)
     setUser(null)
     router.push('/login')

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,12 +1,59 @@
 const BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3333'
 
+const TOKEN_KEY = 'viu_token'
+const REFRESH_KEY = 'viu_refresh_token'
+
 function getToken(): string | null {
   if (typeof window === 'undefined') return null
-  return localStorage.getItem('viu_token')
+  return localStorage.getItem(TOKEN_KEY)
 }
 
-async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+let isRefreshing = false
+let refreshQueue: Array<(token: string | null) => void> = []
+
+async function tryRefresh(): Promise<string | null> {
+  const refreshToken = typeof window !== 'undefined' ? localStorage.getItem(REFRESH_KEY) : null
+  if (!refreshToken) return null
+
+  if (isRefreshing) {
+    return new Promise((resolve) => { refreshQueue.push(resolve) })
+  }
+
+  isRefreshing = true
+  try {
+    const res = await fetch(`${BASE_URL}/auth/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+    })
+    if (!res.ok) {
+      localStorage.removeItem(TOKEN_KEY)
+      localStorage.removeItem(REFRESH_KEY)
+      refreshQueue.forEach((cb) => cb(null))
+      refreshQueue = []
+      return null
+    }
+    const body = await res.json()
+    const newToken: string = body.data.token
+    localStorage.setItem(TOKEN_KEY, newToken)
+    localStorage.setItem(REFRESH_KEY, body.data.refreshToken)
+    if (body.data.usuario) {
+      localStorage.setItem('viu_user', JSON.stringify(body.data.usuario))
+    }
+    refreshQueue.forEach((cb) => cb(newToken))
+    refreshQueue = []
+    return newToken
+  } catch {
+    refreshQueue.forEach((cb) => cb(null))
+    refreshQueue = []
+    return null
+  } finally {
+    isRefreshing = false
+  }
+}
+
+async function request<T>(path: string, init: RequestInit = {}, retry = true): Promise<T> {
   const token = getToken()
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -15,6 +62,15 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   if (token) headers['Authorization'] = `Bearer ${token}`
 
   const res = await fetch(`${BASE_URL}${path}`, { ...init, headers })
+
+  if (res.status === 401 && retry) {
+    const newToken = await tryRefresh()
+    if (newToken) {
+      return request<T>(path, init, false)
+    }
+    throw new Error('Sessão expirada. Faça login novamente.')
+  }
+
   const body = await res.json()
   if (!res.ok) throw new Error(body.message ?? `Erro ${res.status}`)
   return body


### PR DESCRIPTION
## Summary

- `lib/api.ts`: on 401 response, automatically attempts token refresh via `POST /auth/refresh`; concurrent requests hitting 401 simultaneously are queued and resolved once refresh completes; clears all auth storage and throws if refresh fails
- `contexts/AuthContext.tsx`: `signIn` stores `refreshToken` from login response; `signOut` calls `POST /auth/logout` (fire-and-forget) to revoke the server-side session before clearing localStorage

## Test plan

- [ ] Log in → `viu_refresh_token` stored in localStorage
- [ ] With expired access token + valid refresh token: next API call silently refreshes, request succeeds
- [ ] Multiple simultaneous 401s: only one refresh request is made, all callers get the new token
- [ ] Refresh fails (token expired/revoked): storage cleared, error thrown ("Sessão expirada")
- [ ] Sign out → `POST /auth/logout` called, all three keys removed from localStorage

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdRDDdiaAhDYXHupLTaDJE)_