### PR TITLE
feat: 2FA UI — login step, setup, disable, backup codes

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,29 +1,29 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
+  Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle,
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Link from 'next/link';
+import { ShieldCheck } from 'lucide-react';
 
-export default function LoginPage() {
+function LoginContent() {
   const router = useRouter();
   const search = useSearchParams();
   const nextParam = search.get('next');
-  const { signIn } = useAuth();
+  const { signIn, completeTwoFactorLogin } = useAuth();
+
+  const [step, setStep] = useState<'login' | '2fa'>('login');
+  const [pendingUserId, setPendingUserId] = useState('');
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [code, setCode] = useState('');
   const [msg, setMsg] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
 
@@ -31,16 +31,88 @@ export default function LoginPage() {
     e.preventDefault();
     setSending(true);
     setMsg(null);
-
     try {
       await signIn(email, password);
       router.push(nextParam || '/dashboard');
     } catch (err: any) {
+      if (err.message === '2FA_REQUIRED') {
+        setPendingUserId(err.userId);
+        setStep('2fa');
+        return;
+      }
       setMsg(err?.message ?? 'E-mail ou senha inválidos.');
     } finally {
       setSending(false);
     }
   };
+
+  const handle2FA = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSending(true);
+    setMsg(null);
+    try {
+      await completeTwoFactorLogin(pendingUserId, code);
+      router.push(nextParam || '/dashboard');
+    } catch (err: any) {
+      setMsg(err?.message ?? 'Código inválido. Tente novamente.');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (step === '2fa') {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <Card className="w-full max-w-md">
+          <CardHeader className="space-y-2 text-center">
+            <div className="flex justify-center mb-2">
+              <ShieldCheck className="h-10 w-10 text-primary" />
+            </div>
+            <CardTitle className="text-2xl">Verificação em dois fatores</CardTitle>
+            <CardDescription>
+              Digite o código de 6 dígitos do seu aplicativo autenticador (ou um código de backup).
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handle2FA} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="code">Código</Label>
+                <Input
+                  id="code"
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  placeholder="000000"
+                  maxLength={10}
+                  required
+                  value={code}
+                  onChange={(e) => setCode(e.target.value.replace(/\s/g, ''))}
+                  disabled={sending}
+                  className="text-center text-lg tracking-widest"
+                  autoFocus
+                />
+              </div>
+              {msg && (
+                <p className="text-sm text-center text-destructive" aria-live="polite">{msg}</p>
+              )}
+              <Button type="submit" className="w-full" disabled={sending || code.length < 6}>
+                {sending ? 'Verificando...' : 'Verificar'}
+              </Button>
+            </form>
+          </CardContent>
+          <CardFooter className="justify-center">
+            <button
+              type="button"
+              className="text-sm text-muted-foreground hover:underline"
+              onClick={() => { setStep('login'); setCode(''); setMsg(null); }}
+            >
+              Voltar para o login
+            </button>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background">
@@ -52,11 +124,9 @@ export default function LoginPage() {
             </Button>
             <div className="opacity-0 pointer-events-none select-none">←</div>
           </div>
-
           <CardTitle className="text-2xl">Bem-vindo de volta!</CardTitle>
           <CardDescription>Entre para acessar sua conta.</CardDescription>
         </CardHeader>
-
         <CardContent>
           <form onSubmit={handleLogin} className="space-y-4">
             <div className="space-y-2">
@@ -72,7 +142,6 @@ export default function LoginPage() {
                 disabled={sending}
               />
             </div>
-
             <div className="space-y-2">
               <Label htmlFor="password">Senha</Label>
               <Input
@@ -86,19 +155,14 @@ export default function LoginPage() {
                 disabled={sending}
               />
             </div>
-
             {msg && (
-              <p className="text-sm text-center text-destructive" aria-live="polite">
-                {msg}
-              </p>
+              <p className="text-sm text-center text-destructive" aria-live="polite">{msg}</p>
             )}
-
             <Button type="submit" className="w-full" disabled={sending}>
               {sending ? 'Entrando...' : 'Entrar'}
             </Button>
           </form>
         </CardContent>
-
         <CardFooter className="flex justify-between text-sm">
           <Link href="/recuperar" className="text-muted-foreground hover:underline">
             Esqueci minha senha
@@ -109,5 +173,13 @@ export default function LoginPage() {
         </CardFooter>
       </Card>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/app/(dashboard)/configuracoes/page.tsx
+++ b/app/(dashboard)/configuracoes/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '@/lib/api';
 import {
   Card, CardContent, CardHeader, CardTitle,
 } from '@/components/ui/card';
@@ -16,7 +16,8 @@ import { Separator } from '@/components/ui/separator';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
-import { Save, Download, RefreshCw, Trash2, Loader2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Save, Download, RefreshCw, Trash2, Loader2, ShieldCheck, ShieldOff, KeyRound, Copy, Check } from 'lucide-react';
 
 /** ---------- Tipos ---------- */
 interface ConfiguracoesSistema {
@@ -31,49 +32,36 @@ interface ConfiguracoesSistema {
   qualidadeImagem: 'baixa' | 'media' | 'alta' | 'original';
   formatoPadrao: 'PNG' | 'JPG' | 'SVG' | 'PDF';
   backupAutomatico: boolean;
-  retencaoDados: number; // dias
+  retencaoDados: number;
   compartilhamentoPadrao: 'somente_leitura' | 'comentarios' | 'edicao';
   visibilidadePerfil: 'publico' | 'privado' | 'equipe';
   analyticsEnabled: boolean;
 }
-type PrefsRow = { usuario_id: string; prefs: ConfiguracoesSistema; atualizado_em?: string };
 
+const PREFS_KEY = 'viu_prefs';
 const DEFAULT_CONFIGS: ConfiguracoesSistema = {
-  tema: 'claro',
-  idioma: 'pt-BR',
-  timezone: 'America/Sao_Paulo',
-  notificacoesPush: true,
-  notificacoesEmail: true,
-  notificacoesSms: false,
-  emailDigest: 'diario',
-  autoSave: true,
-  qualidadeImagem: 'alta',
-  formatoPadrao: 'PNG',
-  backupAutomatico: true,
-  retencaoDados: 365,
-  compartilhamentoPadrao: 'somente_leitura',
-  visibilidadePerfil: 'publico',
+  tema: 'claro', idioma: 'pt-BR', timezone: 'America/Sao_Paulo',
+  notificacoesPush: true, notificacoesEmail: true, notificacoesSms: false,
+  emailDigest: 'diario', autoSave: true, qualidadeImagem: 'alta',
+  formatoPadrao: 'PNG', backupAutomatico: true, retencaoDados: 365,
+  compartilhamentoPadrao: 'somente_leitura', visibilidadePerfil: 'publico',
   analyticsEnabled: true,
 };
 
-/** ---------- Pequenos componentes ---------- */
-function Row({
-  label, hint, control,
-}: { label: string; hint?: string; control: React.ReactNode }) {
+/** ---------- Helpers de layout ---------- */
+function Row({ label, hint, control }: { label: string; hint?: string; control: React.ReactNode }) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-2 md:gap-6 items-center">
       <div>
         <Label className="font-medium">{label}</Label>
-        {hint ? <p className="text-xs text-muted-foreground mt-0.5">{hint}</p> : null}
+        {hint && <p className="text-xs text-muted-foreground mt-0.5">{hint}</p>}
       </div>
       <div className="md:col-span-2">{control}</div>
     </div>
   );
 }
 
-function ToggleRow({
-  label, hint, checked, onCheckedChange, disabled,
-}: {
+function ToggleRow({ label, hint, checked, onCheckedChange, disabled }: {
   label: string; hint?: string; checked: boolean;
   onCheckedChange: (v: boolean) => void; disabled?: boolean;
 }) {
@@ -81,105 +69,284 @@ function ToggleRow({
     <div className="flex items-center justify-between">
       <div>
         <Label className="font-medium">{label}</Label>
-        {hint ? <p className="text-xs text-muted-foreground mt-0.5">{hint}</p> : null}
+        {hint && <p className="text-xs text-muted-foreground mt-0.5">{hint}</p>}
       </div>
       <Switch checked={checked} onCheckedChange={onCheckedChange} disabled={disabled} />
     </div>
   );
 }
 
-/** ---------- Página ---------- */
+/** ---------- Seção 2FA ---------- */
+type TwoFAStep = 'idle' | 'setup' | 'verify' | 'disable' | 'regenerate' | 'show-backup';
+
+function TwoFactorSection() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [step, setStep] = useState<TwoFAStep>('idle');
+  const [loading, setLoading] = useState(true);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState('');
+
+  const [setupData, setSetupData] = useState<{ qrCode: string; manualEntryKey: string; backupCodes: string[] } | null>(null);
+  const [shownCodes, setShownCodes] = useState<string[]>([]);
+  const [code, setCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await api.get<{ data: { enabled: boolean }; success: boolean }>('/2fa/status');
+      setEnabled(res.data.enabled);
+    } catch {
+      setEnabled(false);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchStatus(); }, [fetchStatus]);
+
+  const handleSetup = async () => {
+    setWorking(true);
+    setError('');
+    try {
+      const res = await api.post<{ data: { qrCode: string; manualEntryKey: string; backupCodes: string[] }; success: boolean }>('/2fa/setup', {});
+      setSetupData(res.data);
+      setStep('setup');
+    } catch (e: any) {
+      setError(e.message ?? 'Erro ao iniciar configuração');
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const handleEnable = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setWorking(true);
+    setError('');
+    try {
+      await api.post('/2fa/enable', { code });
+      setEnabled(true);
+      setSetupData(null);
+      setCode('');
+      setStep('idle');
+    } catch (e: any) {
+      setError(e.message ?? 'Código inválido');
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const handleDisable = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setWorking(true);
+    setError('');
+    try {
+      await api.post('/2fa/disable', { password });
+      setEnabled(false);
+      setPassword('');
+      setStep('idle');
+    } catch (e: any) {
+      setError(e.message ?? 'Senha incorreta');
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const handleRegenerate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setWorking(true);
+    setError('');
+    try {
+      const res = await api.post<{ data: { backupCodes: string[] }; success: boolean }>('/2fa/regenerate-backup-codes', { password });
+      setShownCodes(res.data.backupCodes);
+      setPassword('');
+      setStep('show-backup');
+    } catch (e: any) {
+      setError(e.message ?? 'Senha incorreta');
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const copyBackupCodes = (codes: string[]) => {
+    navigator.clipboard.writeText(codes.join('\n')).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const reset = () => { setStep('idle'); setCode(''); setPassword(''); setError(''); setSetupData(null); setShownCodes([]); };
+
+  if (loading) return <div className="flex justify-center py-4"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium">Autenticação de dois fatores (2FA)</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Proteja sua conta exigindo um código adicional no login.
+          </p>
+        </div>
+        <Badge variant={enabled ? 'default' : 'secondary'}>
+          {enabled ? 'Ativado' : 'Desativado'}
+        </Badge>
+      </div>
+
+      {/* idle — botões de ação */}
+      {step === 'idle' && (
+        <div className="flex gap-2 flex-wrap">
+          {!enabled ? (
+            <Button size="sm" onClick={handleSetup} disabled={working}>
+              {working ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <ShieldCheck className="h-4 w-4 mr-2" />}
+              Configurar 2FA
+            </Button>
+          ) : (
+            <>
+              <Button size="sm" variant="outline" onClick={() => setStep('regenerate')}>
+                <KeyRound className="h-4 w-4 mr-2" /> Regenerar códigos de backup
+              </Button>
+              <Button size="sm" variant="destructive" onClick={() => setStep('disable')}>
+                <ShieldOff className="h-4 w-4 mr-2" /> Desativar 2FA
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* setup — QR Code */}
+      {step === 'setup' && setupData && (
+        <div className="space-y-4 rounded-lg border p-4">
+          <p className="text-sm font-medium">1. Escaneie o QR code com seu app autenticador</p>
+          <div className="flex justify-center">
+            <img src={setupData.qrCode} alt="QR Code 2FA" className="h-48 w-48 rounded border" />
+          </div>
+          <p className="text-xs text-muted-foreground text-center">
+            Ou insira manualmente: <code className="font-mono bg-muted px-1 rounded text-xs">{setupData.manualEntryKey}</code>
+          </p>
+
+          <p className="text-sm font-medium">2. Salve seus códigos de backup</p>
+          <div className="grid grid-cols-2 gap-1">
+            {setupData.backupCodes.map((c) => (
+              <code key={c} className="text-xs font-mono bg-muted rounded px-2 py-1">{c}</code>
+            ))}
+          </div>
+          <Button size="sm" variant="outline" className="w-full" onClick={() => copyBackupCodes(setupData.backupCodes)}>
+            {copied ? <Check className="h-4 w-4 mr-2" /> : <Copy className="h-4 w-4 mr-2" />}
+            {copied ? 'Copiado!' : 'Copiar códigos'}
+          </Button>
+
+          <p className="text-sm font-medium">3. Confirme com o código gerado</p>
+          <form onSubmit={handleEnable} className="space-y-3">
+            <Input
+              type="text"
+              inputMode="numeric"
+              placeholder="000000"
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
+              disabled={working}
+              className="text-center tracking-widest"
+            />
+            {error && <p className="text-xs text-destructive text-center">{error}</p>}
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" className="flex-1" onClick={reset} disabled={working}>Cancelar</Button>
+              <Button type="submit" className="flex-1" disabled={working || code.length < 6}>
+                {working ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Ativar 2FA'}
+              </Button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* disable */}
+      {step === 'disable' && (
+        <form onSubmit={handleDisable} className="space-y-3 rounded-lg border border-destructive/30 p-4">
+          <p className="text-sm text-destructive font-medium">Confirme sua senha para desativar o 2FA</p>
+          <Input type="password" placeholder="Sua senha atual" value={password} onChange={(e) => setPassword(e.target.value)} disabled={working} />
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" className="flex-1" onClick={reset} disabled={working}>Cancelar</Button>
+            <Button type="submit" variant="destructive" className="flex-1" disabled={working || !password}>
+              {working ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Desativar'}
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {/* regenerate */}
+      {step === 'regenerate' && (
+        <form onSubmit={handleRegenerate} className="space-y-3 rounded-lg border p-4">
+          <p className="text-sm font-medium">Confirme sua senha para gerar novos códigos</p>
+          <p className="text-xs text-muted-foreground">Os códigos atuais serão invalidados.</p>
+          <Input type="password" placeholder="Sua senha atual" value={password} onChange={(e) => setPassword(e.target.value)} disabled={working} />
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" className="flex-1" onClick={reset} disabled={working}>Cancelar</Button>
+            <Button type="submit" className="flex-1" disabled={working || !password}>
+              {working ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Gerar novos códigos'}
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {/* show-backup */}
+      {step === 'show-backup' && (
+        <div className="space-y-3 rounded-lg border p-4">
+          <p className="text-sm font-medium">Novos códigos de backup — salve agora</p>
+          <div className="grid grid-cols-2 gap-1">
+            {shownCodes.map((c) => (
+              <code key={c} className="text-xs font-mono bg-muted rounded px-2 py-1">{c}</code>
+            ))}
+          </div>
+          <Button size="sm" variant="outline" className="w-full" onClick={() => copyBackupCodes(shownCodes)}>
+            {copied ? <Check className="h-4 w-4 mr-2" /> : <Copy className="h-4 w-4 mr-2" />}
+            {copied ? 'Copiado!' : 'Copiar códigos'}
+          </Button>
+          <Button size="sm" className="w-full" onClick={reset}>Concluir</Button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** ---------- Página principal ---------- */
 export default function ConfiguracoesPage() {
   const [configs, setConfigs] = useState<ConfiguracoesSistema>(DEFAULT_CONFIGS);
-  const [usuarioId, setUsuarioId] = useState<string | null>(null);
-  const [initializing, setInitializing] = useState(true);
   const [saving, setSaving] = useState(false);
   const [loadingReset, setLoadingReset] = useState(false);
   const [showResetDialog, setShowResetDialog] = useState(false);
   const [showExportDialog, setShowExportDialog] = useState(false);
 
-  /** Resolve usuario_id e carrega prefs */
   useEffect(() => {
-    (async () => {
-      try {
-        setInitializing(true);
-        const { data: auth } = await supabase.auth.getUser();
-        const authUserId = auth.user?.id;
-        if (!authUserId) throw new Error('Usuário não autenticado');
-
-        const { data: map, error: mapErr } = await supabase
-          .from('usuario_auth')
-          .select('usuario_id')
-          .eq('auth_user_id', authUserId)
-          .maybeSingle();
-        if (mapErr) throw mapErr;
-        if (!map?.usuario_id) throw new Error('usuario_auth não encontrado');
-
-        const uid = map.usuario_id as string;
-        setUsuarioId(uid);
-
-        const { data, error } = await supabase
-          .from('usuario_prefs')
-          .select('usuario_id,prefs,atualizado_em')
-          .eq('usuario_id', uid)
-          .maybeSingle();
-
-        if (error) throw error;
-        if (data?.prefs) setConfigs((p) => ({ ...p, ...data.prefs }));
-      } catch (e) {
-        console.warn('[Config] usando defaults; motivo:', e);
-      } finally {
-        setInitializing(false);
-      }
-    })();
+    try {
+      const raw = localStorage.getItem(PREFS_KEY);
+      if (raw) setConfigs((p) => ({ ...p, ...JSON.parse(raw) }));
+    } catch {}
   }, []);
 
-  const handleSave = async () => {
-    if (!usuarioId) return;
+  const handleSave = () => {
     setSaving(true);
     try {
-      const row: PrefsRow = {
-        usuario_id: usuarioId,
-        prefs: configs,
-        atualizado_em: new Date().toISOString(),
-      };
-      const { error } = await supabase.from('usuario_prefs').upsert(row, { onConflict: 'usuario_id' });
-      if (error) throw error;
-    } catch (e) {
-      console.error('[Config] erro ao salvar:', e);
+      localStorage.setItem(PREFS_KEY, JSON.stringify(configs));
     } finally {
-      setSaving(false);
+      setTimeout(() => setSaving(false), 300);
     }
   };
 
-  const handleReset = async () => {
+  const handleReset = () => {
     setLoadingReset(true);
     try {
       setConfigs(DEFAULT_CONFIGS);
-      if (usuarioId) {
-        const row: PrefsRow = {
-          usuario_id: usuarioId,
-          prefs: DEFAULT_CONFIGS,
-          atualizado_em: new Date().toISOString(),
-        };
-        const { error } = await supabase.from('usuario_prefs').upsert(row, { onConflict: 'usuario_id' });
-        if (error) throw error;
-      }
+      localStorage.setItem(PREFS_KEY, JSON.stringify(DEFAULT_CONFIGS));
       setShowResetDialog(false);
-    } catch (e) {
-      console.error('[Config] erro ao resetar:', e);
     } finally {
       setLoadingReset(false);
     }
   };
 
   const handleExport = () => {
-    const payload = {
-      configuracoes: configs,
-      dataExport: new Date().toISOString(),
-      versao: '1.0.0',
-    };
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify({ configuracoes: configs, dataExport: new Date().toISOString(), versao: '1.0.0' }, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -193,257 +360,159 @@ export default function ConfiguracoesPage() {
 
   return (
     <div className="p-6 max-w-3xl mx-auto space-y-4">
-      {/* Header compacto, alinhado com outras telas */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Configurações</h1>
           <p className="text-sm text-muted-foreground">Ajuste preferências da sua conta e do app</p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={() => setShowExportDialog(true)} disabled={initializing}>
+          <Button variant="outline" size="sm" onClick={() => setShowExportDialog(true)}>
             <Download className="h-4 w-4 mr-2" /> Exportar
           </Button>
-          <Button size="sm" onClick={handleSave} disabled={saving || initializing || !usuarioId}>
+          <Button size="sm" onClick={handleSave} disabled={saving}>
             {saving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Save className="h-4 w-4 mr-2" />}
             Salvar
           </Button>
         </div>
       </div>
 
-      {/* Um único Card com seções e divisores — mais clean */}
       <Card className="shadow-sm">
         <CardHeader className="pb-2">
           <CardTitle className="text-base">Preferências</CardTitle>
         </CardHeader>
         <CardContent className="space-y-8">
-          {/* Aparência */}
           <section className="space-y-4">
             <h3 className="text-sm font-medium">Aparência</h3>
             <div className="space-y-4">
-              <Row
-                label="Tema"
-                control={
-                  <Select
-                    value={configs.tema}
-                    onValueChange={(v: ConfiguracoesSistema['tema']) => setConfigs((p) => ({ ...p, tema: v }))}
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="claro">Claro</SelectItem>
-                      <SelectItem value="escuro">Escuro</SelectItem>
-                      <SelectItem value="automatico">Automático</SelectItem>
-                    </SelectContent>
-                  </Select>
-                }
-              />
-              <Row
-                label="Idioma"
-                control={
-                  <Select
-                    value={configs.idioma}
-                    onValueChange={(v: ConfiguracoesSistema['idioma']) => setConfigs((p) => ({ ...p, idioma: v }))}
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="pt-BR">Português (Brasil)</SelectItem>
-                      <SelectItem value="en-US">English (US)</SelectItem>
-                      <SelectItem value="es-ES">Español</SelectItem>
-                    </SelectContent>
-                  </Select>
-                }
-              />
-              <Row
-                label="Fuso horário"
-                control={
-                  <Select
-                    value={configs.timezone}
-                    onValueChange={(v: ConfiguracoesSistema['timezone']) => setConfigs((p) => ({ ...p, timezone: v }))}
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="America/Sao_Paulo">São Paulo (GMT-3)</SelectItem>
-                      <SelectItem value="America/New_York">New York (GMT-5)</SelectItem>
-                      <SelectItem value="Europe/London">London (GMT+0)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                }
-              />
+              <Row label="Tema" control={
+                <Select value={configs.tema} onValueChange={(v: ConfiguracoesSistema['tema']) => setConfigs((p) => ({ ...p, tema: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="claro">Claro</SelectItem>
+                    <SelectItem value="escuro">Escuro</SelectItem>
+                    <SelectItem value="automatico">Automático</SelectItem>
+                  </SelectContent>
+                </Select>
+              } />
+              <Row label="Idioma" control={
+                <Select value={configs.idioma} onValueChange={(v: ConfiguracoesSistema['idioma']) => setConfigs((p) => ({ ...p, idioma: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="pt-BR">Português (Brasil)</SelectItem>
+                    <SelectItem value="en-US">English (US)</SelectItem>
+                    <SelectItem value="es-ES">Español</SelectItem>
+                  </SelectContent>
+                </Select>
+              } />
+              <Row label="Fuso horário" control={
+                <Select value={configs.timezone} onValueChange={(v: ConfiguracoesSistema['timezone']) => setConfigs((p) => ({ ...p, timezone: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="America/Sao_Paulo">São Paulo (GMT-3)</SelectItem>
+                    <SelectItem value="America/New_York">New York (GMT-5)</SelectItem>
+                    <SelectItem value="Europe/London">London (GMT+0)</SelectItem>
+                  </SelectContent>
+                </Select>
+              } />
             </div>
           </section>
 
           <Separator />
 
-          {/* Notificações */}
           <section className="space-y-4">
             <h3 className="text-sm font-medium">Notificações</h3>
             <div className="space-y-3">
-              <ToggleRow
-                label="Notificações push"
-                hint="Receba alertas no navegador"
-                checked={configs.notificacoesPush}
-                onCheckedChange={(v) => setConfigs((p) => ({ ...p, notificacoesPush: v }))}
-              />
-              <ToggleRow
-                label="Notificações por e-mail"
-                checked={configs.notificacoesEmail}
-                onCheckedChange={(v) => setConfigs((p) => ({ ...p, notificacoesEmail: v }))}
-              />
-              <ToggleRow
-                label="Notificações por SMS"
-                checked={configs.notificacoesSms}
-                onCheckedChange={(v) => setConfigs((p) => ({ ...p, notificacoesSms: v }))}
-              />
-              <Row
-                label="Resumo por e-mail"
-                control={
-                  <Select
-                    value={configs.emailDigest}
-                    onValueChange={(v: ConfiguracoesSistema['emailDigest']) => setConfigs((p) => ({ ...p, emailDigest: v }))}
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="nunca">Nunca</SelectItem>
-                      <SelectItem value="diario">Diário</SelectItem>
-                      <SelectItem value="semanal">Semanal</SelectItem>
-                      <SelectItem value="mensal">Mensal</SelectItem>
-                    </SelectContent>
-                  </Select>
-                }
-              />
+              <ToggleRow label="Notificações push" hint="Receba alertas no navegador" checked={configs.notificacoesPush} onCheckedChange={(v) => setConfigs((p) => ({ ...p, notificacoesPush: v }))} />
+              <ToggleRow label="Notificações por e-mail" checked={configs.notificacoesEmail} onCheckedChange={(v) => setConfigs((p) => ({ ...p, notificacoesEmail: v }))} />
+              <ToggleRow label="Notificações por SMS" checked={configs.notificacoesSms} onCheckedChange={(v) => setConfigs((p) => ({ ...p, notificacoesSms: v }))} />
+              <Row label="Resumo por e-mail" control={
+                <Select value={configs.emailDigest} onValueChange={(v: ConfiguracoesSistema['emailDigest']) => setConfigs((p) => ({ ...p, emailDigest: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="nunca">Nunca</SelectItem>
+                    <SelectItem value="diario">Diário</SelectItem>
+                    <SelectItem value="semanal">Semanal</SelectItem>
+                    <SelectItem value="mensal">Mensal</SelectItem>
+                  </SelectContent>
+                </Select>
+              } />
             </div>
           </section>
 
           <Separator />
 
-          {/* Sistema */}
           <section className="space-y-4">
             <h3 className="text-sm font-medium">Sistema</h3>
             <div className="space-y-3">
-              <ToggleRow
-                label="Salvamento automático"
-                checked={configs.autoSave}
-                onCheckedChange={(v) => setConfigs((p) => ({ ...p, autoSave: v }))}
-              />
-              <ToggleRow
-                label="Backup automático"
-                checked={configs.backupAutomatico}
-                onCheckedChange={(v) => setConfigs((p) => ({ ...p, backupAutomatico: v }))}
-              />
+              <ToggleRow label="Salvamento automático" checked={configs.autoSave} onCheckedChange={(v) => setConfigs((p) => ({ ...p, autoSave: v }))} />
+              <ToggleRow label="Backup automático" checked={configs.backupAutomatico} onCheckedChange={(v) => setConfigs((p) => ({ ...p, backupAutomatico: v }))} />
             </div>
             <div className="space-y-4">
-              <Row
-                label="Qualidade de imagem"
-                control={
-                  <Select
-                    value={configs.qualidadeImagem}
-                    onValueChange={(v: ConfiguracoesSistema['qualidadeImagem']) =>
-                      setConfigs((p) => ({ ...p, qualidadeImagem: v }))
-                    }
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="baixa">Baixa</SelectItem>
-                      <SelectItem value="media">Média</SelectItem>
-                      <SelectItem value="alta">Alta</SelectItem>
-                      <SelectItem value="original">Original</SelectItem>
-                    </SelectContent>
-                  </Select>
-                }
-              />
-              <Row
-                label="Formato padrão de exportação"
-                control={
-                  <Select
-                    value={configs.formatoPadrao}
-                    onValueChange={(v: ConfiguracoesSistema['formatoPadrao']) =>
-                      setConfigs((p) => ({ ...p, formatoPadrao: v }))
-                    }
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="PNG">PNG</SelectItem>
-                      <SelectItem value="JPG">JPG</SelectItem>
-                      <SelectItem value="SVG">SVG</SelectItem>
-                      <SelectItem value="PDF">PDF</SelectItem>
-                    </SelectContent>
-                  </Select>
-                }
-              />
+              <Row label="Qualidade de imagem" control={
+                <Select value={configs.qualidadeImagem} onValueChange={(v: ConfiguracoesSistema['qualidadeImagem']) => setConfigs((p) => ({ ...p, qualidadeImagem: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="baixa">Baixa</SelectItem>
+                    <SelectItem value="media">Média</SelectItem>
+                    <SelectItem value="alta">Alta</SelectItem>
+                    <SelectItem value="original">Original</SelectItem>
+                  </SelectContent>
+                </Select>
+              } />
+              <Row label="Formato padrão de exportação" control={
+                <Select value={configs.formatoPadrao} onValueChange={(v: ConfiguracoesSistema['formatoPadrao']) => setConfigs((p) => ({ ...p, formatoPadrao: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="PNG">PNG</SelectItem>
+                    <SelectItem value="JPG">JPG</SelectItem>
+                    <SelectItem value="SVG">SVG</SelectItem>
+                    <SelectItem value="PDF">PDF</SelectItem>
+                  </SelectContent>
+                </Select>
+              } />
             </div>
           </section>
 
           <Separator />
 
-          {/* Privacidade */}
           <section className="space-y-4">
             <h3 className="text-sm font-medium">Privacidade</h3>
             <div className="space-y-4">
-              <Row
-                label="Visibilidade do perfil"
-                control={
-                  <Select
-                    value={configs.visibilidadePerfil}
-                    onValueChange={(v: ConfiguracoesSistema['visibilidadePerfil']) =>
-                      setConfigs((p) => ({ ...p, visibilidadePerfil: v }))
-                    }
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="publico">Público</SelectItem>
-                      <SelectItem value="privado">Privado</SelectItem>
-                      <SelectItem value="equipe">Apenas equipe</SelectItem>
-                    </SelectContent>
-                  </Select>
-                }
-              />
-              <Row
-                label="Compartilhamento padrão"
-                hint="Define o comportamento ao criar links em link_compartilhado"
-                control={
-                  <Select
-                    value={configs.compartilhamentoPadrao}
-                    onValueChange={(v: ConfiguracoesSistema['compartilhamentoPadrao']) =>
-                      setConfigs((p) => ({ ...p, compartilhamentoPadrao: v }))
-                    }
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="somente_leitura">Somente leitura</SelectItem>
-                      <SelectItem value="comentarios">Permitir comentários</SelectItem>
-                      <SelectItem value="edicao">Permitir edição</SelectItem>
-                    </SelectContent>
-                  </Select>
-                }
-              />
-              <ToggleRow
-                label="Analytics"
-                hint="Permitir coleta anônima para melhoria do produto"
-                checked={configs.analyticsEnabled}
-                onCheckedChange={(v) => setConfigs((p) => ({ ...p, analyticsEnabled: v }))}
-              />
-              <Row
-                label="Retenção de dados (dias)"
-                control={
-                  <Input
-                    type="number"
-                    value={configs.retencaoDados}
-                    onChange={(e) =>
-                      setConfigs((p) => ({
-                        ...p,
-                        retencaoDados: Number.isFinite(Number(e.target.value))
-                          ? Math.max(1, parseInt(e.target.value, 10))
-                          : 365,
-                      }))
-                    }
-                  />
-                }
-              />
+              <Row label="Visibilidade do perfil" control={
+                <Select value={configs.visibilidadePerfil} onValueChange={(v: ConfiguracoesSistema['visibilidadePerfil']) => setConfigs((p) => ({ ...p, visibilidadePerfil: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="publico">Público</SelectItem>
+                    <SelectItem value="privado">Privado</SelectItem>
+                    <SelectItem value="equipe">Apenas equipe</SelectItem>
+                  </SelectContent>
+                </Select>
+              } />
+              <Row label="Compartilhamento padrão" hint="Define o comportamento ao criar links compartilhados" control={
+                <Select value={configs.compartilhamentoPadrao} onValueChange={(v: ConfiguracoesSistema['compartilhamentoPadrao']) => setConfigs((p) => ({ ...p, compartilhamentoPadrao: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="somente_leitura">Somente leitura</SelectItem>
+                    <SelectItem value="comentarios">Permitir comentários</SelectItem>
+                    <SelectItem value="edicao">Permitir edição</SelectItem>
+                  </SelectContent>
+                </Select>
+              } />
+              <ToggleRow label="Analytics" hint="Permitir coleta anônima para melhoria do produto" checked={configs.analyticsEnabled} onCheckedChange={(v) => setConfigs((p) => ({ ...p, analyticsEnabled: v }))} />
+              <Row label="Retenção de dados (dias)" control={
+                <Input type="number" value={configs.retencaoDados} onChange={(e) =>
+                  setConfigs((p) => ({ ...p, retencaoDados: Math.max(1, parseInt(e.target.value, 10) || 365) }))
+                } />
+              } />
             </div>
           </section>
+
+          <Separator />
+
+          <TwoFactorSection />
         </CardContent>
       </Card>
 
-      {/* Zona de Perigo minimalista */}
       <Card className="border-destructive/20">
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium text-destructive">Zona de perigo</CardTitle>
@@ -454,7 +523,7 @@ export default function ConfiguracoesPage() {
             <p className="text-muted-foreground">Volta tudo para os valores padrão</p>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={() => setShowResetDialog(true)} disabled={initializing}>
+            <Button variant="outline" size="sm" onClick={() => setShowResetDialog(true)}>
               <RefreshCw className="h-4 w-4 mr-2" /> Resetar
             </Button>
             <Button variant="destructive" size="sm" disabled>
@@ -464,7 +533,6 @@ export default function ConfiguracoesPage() {
         </CardContent>
       </Card>
 
-      {/* Dialogs */}
       <Dialog open={showResetDialog} onOpenChange={setShowResetDialog}>
         <DialogContent>
           <DialogHeader>
@@ -473,7 +541,7 @@ export default function ConfiguracoesPage() {
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowResetDialog(false)}>Cancelar</Button>
-            <Button onClick={handleReset} disabled={loadingReset || initializing}>
+            <Button onClick={handleReset} disabled={loadingReset}>
               {loadingReset ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <RefreshCw className="h-4 w-4 mr-2" />}
               Resetar
             </Button>

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ type AuthContextType = {
   user: UserProfile | null
   token: string | null
   signIn: (email: string, senha: string) => Promise<void>
+  completeTwoFactorLogin: (userId: string, code: string) => Promise<void>
   signOut: () => void
   loading: boolean
 }
@@ -58,6 +59,12 @@ function loadFromStorage(): { token: string | null; user: UserProfile | null } {
   }
 }
 
+function storeSession(token: string, refreshToken: string | undefined, usuario: UserProfile) {
+  localStorage.setItem(TOKEN_KEY, token)
+  localStorage.setItem(USER_KEY, JSON.stringify(usuario))
+  if (refreshToken) localStorage.setItem(REFRESH_KEY, refreshToken)
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(null)
   const [user, setUser] = useState<UserProfile | null>(null)
@@ -72,14 +79,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const signIn = useCallback(async (email: string, senha: string) => {
+    const res = await api.post<{
+      data: { token?: string; refreshToken?: string; usuario?: UserProfile; requires2FA?: boolean; userId?: string }
+      success: boolean
+    }>('/auth/login', { email, senha })
+
+    const data = res.data
+    if (data.requires2FA) {
+      const err: any = new Error('2FA_REQUIRED')
+      err.userId = data.userId
+      throw err
+    }
+
+    storeSession(data.token!, data.refreshToken, data.usuario!)
+    setToken(data.token!)
+    setUser(data.usuario!)
+  }, [])
+
+  const completeTwoFactorLogin = useCallback(async (userId: string, code: string) => {
     const res = await api.post<{ data: { token: string; refreshToken: string; usuario: UserProfile }; success: boolean }>(
-      '/auth/login',
-      { email, senha }
+      '/auth/2fa-login',
+      { userId, code }
     )
     const { token: newToken, refreshToken, usuario } = res.data
-    localStorage.setItem(TOKEN_KEY, newToken)
-    localStorage.setItem(USER_KEY, JSON.stringify(usuario))
-    if (refreshToken) localStorage.setItem(REFRESH_KEY, refreshToken)
+    storeSession(newToken, refreshToken, usuario)
     setToken(newToken)
     setUser(usuario)
   }, [])
@@ -101,7 +124,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [router])
 
   return (
-    <AuthContext.Provider value={{ user, token, signIn, signOut, loading }}>
+    <AuthContext.Provider value={{ user, token, signIn, completeTwoFactorLogin, signOut, loading }}>
       {children}
     </AuthContext.Provider>
   )


### PR DESCRIPTION
## Summary

- **Login page**: detects `requires2FA` response from backend and shows a second step with OTP input; page wrapped in `Suspense` for `useSearchParams`
- **AuthContext**: `signIn` throws `2FA_REQUIRED` error with `userId`; new `completeTwoFactorLogin(userId, code)` calls `POST /auth/2fa-login` and stores the session
- **Configurações page**: removed Supabase entirely (preferences now stored in `localStorage`); added full 2FA management section:
  - Status badge (Ativado / Desativado)
  - Setup flow: QR code display + manual entry key + backup codes shown once + code confirmation
  - Copy backup codes to clipboard
  - Disable 2FA (requires password)
  - Regenerate backup codes (requires password, shows new codes)

## Test plan

- [ ] Login with 2FA account → see OTP input step
- [ ] Enter correct code → redirected to dashboard
- [ ] Enter wrong code → error message, can retry
- [ ] Click "Voltar para o login" → return to email/password step
- [ ] Settings → 2FA section shows correct status
- [ ] Click "Configurar 2FA" → QR code + backup codes appear
- [ ] Enter code from authenticator → 2FA enabled, badge turns green
- [ ] "Regenerar códigos de backup" → new codes shown, copy works
- [ ] "Desativar 2FA" → requires password, disables on success

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdRDDdiaAhDYXHupLTaDJE)_