### PR TITLE
feat: briefing quality check UI + remove Supabase from projetos

### DIFF
--- a/app/(dashboard)/projetos/page.tsx
+++ b/app/(dashboard)/projetos/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { supabase } from "@/lib/supabaseClient";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -126,7 +125,7 @@ export default function ProjetosPage() {
   }), [rows]);
 
   // CRUD
-  const onCreate = async (values: ProjetoInput) => {
+  const onCreate = async (values: ProjetoInput & { skipBriefingEval?: boolean }) => {
     setBusy(true);
     try {
       const novo = await createProjeto(values);
@@ -134,6 +133,8 @@ export default function ProjetosPage() {
       toast.success("Projeto criado. Bora brilhar ✨");
       setOpenModal(false);
     } catch (e: any) {
+      // 422 briefing eval errors are handled by the modal — propagate without toast
+      if ((e as any)?.status === 422) throw e;
       toast.error(e?.message ?? "Erro ao criar projeto"); throw e;
     } finally { setBusy(false); }
   };
@@ -154,18 +155,12 @@ export default function ProjetosPage() {
     if (!confirm("Jogar fora? Tem certeza? Ainda dá tempo de desfazer…")) return;
     setBusy(true);
     try {
-      const [{ count: artesCount, error: aErr }, { count: tarefasCount, error: tErr }] = await Promise.all([
-        supabase.from("artes").select("id", { count: "exact", head: true }).eq("projeto_id", id),
-        supabase.from("tarefas").select("id", { count: "exact", head: true }).eq("projeto_id", id),
-      ]);
-      if (aErr || tErr) throw aErr || tErr;
-      if ((artesCount ?? 0) > 0 || (tarefasCount ?? 0) > 0) {
-        toast.error("Não é possível excluir: existem artes e/ou tarefas vinculadas."); return;
-      }
       setRows((prev) => prev.filter((p) => p.id !== id));
       await deleteProjeto(id);
       toast.success("Projeto excluído!");
     } catch (e: any) {
+      // Rollback optimistic remove on failure
+      await reload();
       toast.error(e?.message ?? "Erro ao excluir");
     } finally { setBusy(false); }
   };

--- a/components/projetos/ProjetoModal.tsx
+++ b/components/projetos/ProjetoModal.tsx
@@ -2,10 +2,12 @@
 
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
-import { supabase } from "@/lib/supabaseClient";
+import { useAuth } from "@/contexts/AuthContext";
+import { listClientes, listDesigners } from "@/lib/projects";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, AlertTriangle, CheckCircle2, RotateCcw } from "lucide-react";
 import type { ProjetoInput } from "@/lib/projects";
 import { Stepper } from "@/components/ui/stepper";
 
@@ -16,62 +18,114 @@ import StepApproval from "./forms/StepApproval";
 import StepReview from "./forms/StepReview";
 import type { ProjetoExtraPayload } from "./project-extra-types";
 
-// ===== tipos originais =====
 type StatusProjeto = "EM_ANDAMENTO" | "CONCLUIDO" | "PAUSADO";
 export type ProjetoInitial = {
   id: string; nome: string; descricao?: string | null; status: StatusProjeto;
   orcamento: number; prazo?: string | null; cliente_id?: string | null;
 };
 
+interface DimensionScore {
+  score: number;
+  justification: string;
+}
+
+interface EvalResult {
+  passed: boolean;
+  verdict: "PASS" | "FAIL";
+  scores: Record<string, DimensionScore>;
+}
+
 interface ProjetoModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   initial?: ProjetoInitial | null;
-  onSubmit?: (values: ProjetoInput & ProjetoExtraPayload) => Promise<void>;
+  onSubmit?: (values: ProjetoInput & ProjetoExtraPayload & { skipBriefingEval?: boolean }) => Promise<void>;
 }
 
-// ===== utils (mesmos que você já tinha) =====
-function safeErrorToString(err: unknown) {
-  try {
-    if (!err) return "Erro desconhecido";
-    if (typeof err === "string") return err;
-    if (err instanceof Error) return err.message || (err as any).name || "Erro";
-    if (typeof err === "object") {
-      const anyErr = err as any;
-      if (anyErr.message) return anyErr.message;
-      return JSON.stringify(err);
-    }
-    return String(err);
-  } catch {
-    return "Erro ao serializar o erro";
-  }
-}
 const isUuidLike = (v?: string | null) => !!v && v.length === 36;
-async function ensureUsuarioExiste() {
-  const { data: auth, error: authErr } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
-  const u = auth?.user;
-  if (!u) throw new Error("Não autenticado.");
-  const { data: me, error: meErr } = await supabase.from("usuarios").select("id").eq("id", u.id).maybeSingle();
-  if (meErr) throw meErr;
-  if (me) return;
-  const nome =
-    (u.user_metadata?.full_name as string) ||
-    (u.user_metadata?.name as string) ||
-    (u.email?.split("@")[0] as string) ||
-    "Usuário";
-  const { error: insErr } = await supabase.from("usuarios").insert({ id: u.id, email: u.email, nome });
-  if (insErr) throw insErr;
+
+const DIMENSION_LABELS: Record<string, string> = {
+  completude: "Completude",
+  clareza: "Clareza",
+  acionabilidade: "Acionabilidade",
+};
+
+function ScoreBar({ score }: { score: number }) {
+  const pct = (score / 10) * 100;
+  const color = score >= 7 ? "bg-green-500" : score >= 5 ? "bg-yellow-500" : "bg-red-500";
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
+        <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-sm font-medium w-8 text-right">{score.toFixed(1)}</span>
+    </div>
+  );
 }
 
-// ===== componente =====
+function BriefingEvalPanel({
+  evalResult,
+  onImprove,
+  onSkip,
+  loading,
+}: {
+  evalResult: EvalResult;
+  onImprove: () => void;
+  onSkip: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-3 p-4 bg-yellow-50 dark:bg-yellow-950/30 rounded-lg border border-yellow-200 dark:border-yellow-800">
+        <AlertTriangle className="h-5 w-5 text-yellow-600 shrink-0 mt-0.5" />
+        <div>
+          <p className="text-sm font-semibold text-yellow-800 dark:text-yellow-300">
+            O briefing precisa de melhorias
+          </p>
+          <p className="text-xs text-yellow-700 dark:text-yellow-400 mt-0.5">
+            A análise identificou pontos que podem dificultar o trabalho do designer. Melhore o briefing ou crie o projeto assim mesmo.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {Object.entries(evalResult.scores).map(([key, dim]) => (
+          <div key={key} className="space-y-1">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">{DIMENSION_LABELS[key] ?? key}</span>
+              <Badge variant={dim.score >= 7 ? "default" : dim.score >= 5 ? "secondary" : "destructive"} className="text-xs">
+                {dim.score >= 7 ? "Bom" : dim.score >= 5 ? "Regular" : "Fraco"}
+              </Badge>
+            </div>
+            <ScoreBar score={dim.score} />
+            <p className="text-xs text-muted-foreground">{dim.justification}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex gap-2 pt-2">
+        <Button variant="outline" className="flex-1" onClick={onImprove}>
+          <RotateCcw className="h-4 w-4 mr-2" />
+          Melhorar briefing
+        </Button>
+        <Button variant="ghost" className="flex-1 text-muted-foreground" onClick={onSkip} disabled={loading}>
+          {loading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+          Criar mesmo assim
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export default function ProjetoModal({ open, onOpenChange, initial, onSubmit }: ProjetoModalProps) {
+  const { user } = useAuth();
   const [loading, setLoading] = useState(false);
   const [salvando, setSalvando] = useState(false);
   const [clientes, setClientes] = useState<ClienteOption[]>([]);
   const [designers, setDesigners] = useState<UsuarioOption[]>([]);
   const [souCliente, setSouCliente] = useState(false);
   const [step, setStep] = useState(0);
+  const [evalResult, setEvalResult] = useState<EvalResult | null>(null);
 
   const steps = [
     { key: "basic", label: "Básico" },
@@ -100,44 +154,29 @@ export default function ProjetoModal({ open, onOpenChange, initial, onSubmit }: 
     },
   });
 
-  // Boot
   useEffect(() => {
     const boot = async () => {
       if (!open) return;
       setLoading(true);
+      setEvalResult(null);
       try {
-        await ensureUsuarioExiste();
-        const { data: auth } = await supabase.auth.getUser();
-        const userId = auth?.user?.id ?? null;
-
-        if (userId) {
-          const { data: me } = await supabase.from("usuarios").select("id, tipo").eq("id", userId).maybeSingle();
-          if (me?.tipo === "CLIENTE") {
-            setSouCliente(true);
-            setFormData((prev) => ({ ...prev, cliente_id: me.id }));
-          } else {
-            setSouCliente(false);
-          }
+        const isCli = user?.tipo === "CLIENTE";
+        setSouCliente(isCli);
+        if (isCli && user?.id) {
+          setFormData((prev) => ({ ...prev, cliente_id: user.id }));
         }
 
-        const [cli, des] = await Promise.all([
-          supabase.from("usuarios").select("id, nome").eq("tipo", "CLIENTE").eq("ativo", true).order("nome"),
-          supabase.from("usuarios").select("id, nome").eq("tipo", "DESIGNER").eq("ativo", true).order("nome"),
-        ]);
-        if (cli.error) throw cli.error;
-        if (des.error) throw des.error;
+        const [cliList, desList] = await Promise.all([listClientes(), listDesigners()]);
+        setClientes(cliList);
+        setDesigners(desList);
 
-        setClientes((cli.data ?? []).map((c) => ({ id: c.id as string, nome: c.nome as string })));
-        setDesigners((des.data ?? []).map((d) => ({ id: d.id as string, nome: d.nome as string })));
-
-        // auto-select 1º cliente se não for cliente logado
-        if (!souCliente && !formData.cliente_id && (cli.data ?? []).length > 0) {
-          setFormData((prev) => ({ ...prev, cliente_id: (cli.data![0].id as string) }));
+        if (!isCli && !formData.cliente_id && cliList.length > 0) {
+          setFormData((prev) => ({ ...prev, cliente_id: cliList[0].id }));
         }
 
-        setStep(0); // sempre começa no passo 0 ao abrir
+        setStep(0);
       } catch (e) {
-        console.error("Erro boot modal projeto:", safeErrorToString(e));
+        console.error("Erro ao carregar modal:", e);
       } finally {
         setLoading(false);
       }
@@ -146,7 +185,6 @@ export default function ProjetoModal({ open, onOpenChange, initial, onSubmit }: 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  // Editar
   useEffect(() => {
     if (initial) {
       setFormData((prev) => ({
@@ -164,10 +202,10 @@ export default function ProjetoModal({ open, onOpenChange, initial, onSubmit }: 
         nome: "", descricao: "", status: "EM_ANDAMENTO", orcamento: 0, prazo: "", cliente_id: prev.cliente_id || "",
       }));
     }
+    setEvalResult(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initial, open]);
 
-  // ===== validações por step =====
   const invalidBasic = useMemo(() => {
     const nomeOk = formData.nome.trim().length > 0;
     const orcOk = Number.isFinite(formData.orcamento);
@@ -175,19 +213,10 @@ export default function ProjetoModal({ open, onOpenChange, initial, onSubmit }: 
     return !(nomeOk && orcOk && cliOk);
   }, [formData, souCliente]);
 
-  // participantes: nada obrigatório
-  // aprovação: se marcou aprovadores, ok; se não marcou e "todos obrigatórios" = true, continua ok (opções livres)
-
-  // ===== submissão =====
-  const handleSubmitFinal = async () => {
+  const handleSubmitFinal = async (skipBriefingEval = false) => {
     setSalvando(true);
     try {
-      await ensureUsuarioExiste();
-      const { data: auth } = await supabase.auth.getUser();
-      const userId = auth?.user?.id;
-      if (!userId) throw new Error("Usuário não autenticado.");
-
-      const clienteId = souCliente ? userId : (isUuidLike(formData.cliente_id) ? formData.cliente_id! : null);
+      const clienteId = souCliente ? (user?.id ?? null) : (isUuidLike(formData.cliente_id) ? formData.cliente_id : null);
       if (!clienteId) throw new Error("Selecione um cliente.");
 
       const prazoISO: string | null = formData.prazo ? new Date(formData.prazo).toISOString() : null;
@@ -200,61 +229,43 @@ export default function ProjetoModal({ open, onOpenChange, initial, onSubmit }: 
         cliente_id: clienteId,
         orcamento: Number.isFinite(formData.orcamento) ? formData.orcamento : 0,
       };
+
       const extra: ProjetoExtraPayload = {
         aprovacao: { ...formData.aprovacao },
         participantes: { ...formData.participantes },
       };
 
       if (onSubmit) {
-        await onSubmit({ ...baseValues, ...extra });
-      } else {
-        // fallback simples (sem extras)
-        const orcCents = Math.round((baseValues.orcamento ?? 0) * 100);
-        const { error } = await supabase.from("projetos").insert({
-          nome: baseValues.nome,
-          descricao: baseValues.descricao ?? null,
-          status: baseValues.status,
-          orcamento: orcCents,
-          prazo: baseValues.prazo,
-          designer_id: userId,
-          cliente_id: baseValues.cliente_id,
-        }).select("id").single();
-        if (error) throw error;
+        await onSubmit({ ...baseValues, ...extra, skipBriefingEval });
+        onOpenChange(false);
       }
-
-      onOpenChange(false);
-    } catch (e) {
-      console.error("Erro ao salvar:", safeErrorToString(e));
+    } catch (err: any) {
+      if (err?.status === 422 && err?.body?.evalResult) {
+        setEvalResult(err.body.evalResult as EvalResult);
+        return;
+      }
+      console.error("Erro ao salvar projeto:", err?.message ?? err);
     } finally {
       setSalvando(false);
     }
   };
 
-  // ===== resumo para a revisão =====
   const resumo = useMemo(() => {
-    const nomeCliente = clientes.find(c => c.id === formData.cliente_id)?.nome;
+    const nomeCliente = clientes.find((c) => c.id === formData.cliente_id)?.nome;
     const designersAd = formData.participantes.designersAdicionaisIds
-      .map(id => designers.find(d => d.id === id)?.nome || id);
-    const clientesAd  = formData.participantes.clientesAdicionaisIds
-      .map(id => clientes.find(c => c.id === id)?.nome || id);
+      .map((id) => designers.find((d) => d.id === id)?.nome || id);
+    const clientesAd = formData.participantes.clientesAdicionaisIds
+      .map((id) => clientes.find((c) => c.id === id)?.nome || id);
     const aprovadores = formData.aprovacao.aprovadoresClienteIds
-      .map(id => clientes.find(c => c.id === id)?.nome || id);
-
+      .map((id) => clientes.find((c) => c.id === id)?.nome || id);
     const statusLabel = formData.status === "EM_ANDAMENTO" ? "Em andamento" :
-                        formData.status === "CONCLUIDO" ? "Concluído" : "Pausado";
+      formData.status === "CONCLUIDO" ? "Concluído" : "Pausado";
     const orcFmt = new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(formData.orcamento || 0);
     const prazoFmt = formData.prazo ? new Date(formData.prazo).toLocaleDateString("pt-BR") : undefined;
-
     return {
-      nome: formData.nome,
-      cliente: nomeCliente,
-      prazo: prazoFmt,
-      orcamento: orcFmt,
-      status: statusLabel,
-      designersAdicionais: designersAd,
-      clientesAdicionais: clientesAd,
-      aprovadores,
-      exigirAprovDesigner: formData.aprovacao.exigirAprovacaoDesigner,
+      nome: formData.nome, cliente: nomeCliente, prazo: prazoFmt, orcamento: orcFmt,
+      status: statusLabel, designersAdicionais: designersAd, clientesAdicionais: clientesAd,
+      aprovadores, exigirAprovDesigner: formData.aprovacao.exigirAprovacaoDesigner,
       todosObrigatorios: formData.aprovacao.todosAprovadoresSaoObrigatorios,
       overrideOwner: formData.aprovacao.permitirOverrideOwner,
       prazoAprovDias: formData.aprovacao.prazoAprovacaoDias ?? null,
@@ -268,7 +279,6 @@ export default function ProjetoModal({ open, onOpenChange, initial, onSubmit }: 
           <DialogTitle>{initial ? "Editar Projeto" : "Novo Projeto"}</DialogTitle>
         </DialogHeader>
 
-        {/* Stepper */}
         <div className="mb-4">
           <Stepper
             steps={[
@@ -281,53 +291,46 @@ export default function ProjetoModal({ open, onOpenChange, initial, onSubmit }: 
           />
         </div>
 
-          {/* Conteúdo */}
-          <div className="min-h-[260px]">
-            {step === 0 && (
-              <StepBasic
-                values={formData}
-                setValues={setFormData}
-                souCliente={souCliente}
-              />
-            )}
-            {step === 1 && (
-              <StepParticipants
-                values={formData}
-                setValues={setFormData}
-                souCliente={souCliente}
-              />
-            )}
-            {step === 2 && (
-              <StepApproval
-                values={formData}
-                setValues={setFormData}
-              />
-            )}
-            {step === 3 && <StepReview resumo={resumo} />}
-          </div>
-
-
-        {/* Navegação */}
-        <div className="flex justify-between pt-2">
-          <Button variant="outline" onClick={() => (step > 0 ? setStep(step - 1) : onOpenChange(false))}>
-            {step > 0 ? "Voltar" : "Cancelar"}
-          </Button>
-
-          {step < steps.length - 1 ? (
-            <Button
-              onClick={() => setStep(step + 1)}
-              disabled={(step === 0 && (loading || invalidBasic))}
-              title={step === 0 && invalidBasic ? "Preencha nome, valor e cliente" : undefined}
-            >
-              Próximo
-            </Button>
+        <div className="min-h-[260px]">
+          {evalResult ? (
+            <BriefingEvalPanel
+              evalResult={evalResult}
+              onImprove={() => { setEvalResult(null); setStep(0); }}
+              onSkip={() => handleSubmitFinal(true)}
+              loading={salvando}
+            />
           ) : (
-            <Button onClick={handleSubmitFinal} disabled={salvando || loading}>
-              {salvando && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {initial ? "Salvar" : "Criar"}
-            </Button>
+            <>
+              {step === 0 && <StepBasic values={formData} setValues={setFormData} souCliente={souCliente} />}
+              {step === 1 && <StepParticipants values={formData} setValues={setFormData} souCliente={souCliente} />}
+              {step === 2 && <StepApproval values={formData} setValues={setFormData} />}
+              {step === 3 && <StepReview resumo={resumo} />}
+            </>
           )}
         </div>
+
+        {!evalResult && (
+          <div className="flex justify-between pt-2">
+            <Button variant="outline" onClick={() => (step > 0 ? setStep(step - 1) : onOpenChange(false))}>
+              {step > 0 ? "Voltar" : "Cancelar"}
+            </Button>
+
+            {step < steps.length - 1 ? (
+              <Button
+                onClick={() => setStep(step + 1)}
+                disabled={step === 0 && (loading || invalidBasic)}
+                title={step === 0 && invalidBasic ? "Preencha nome, valor e cliente" : undefined}
+              >
+                Próximo
+              </Button>
+            ) : (
+              <Button onClick={() => handleSubmitFinal(false)} disabled={salvando || loading}>
+                {salvando && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {initial ? "Salvar" : "Criar"}
+              </Button>
+            )}
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -72,7 +72,12 @@ async function request<T>(path: string, init: RequestInit = {}, retry = true): P
   }
 
   const body = await res.json()
-  if (!res.ok) throw new Error(body.message ?? `Erro ${res.status}`)
+  if (!res.ok) {
+    const err = new Error(body.message ?? `Erro ${res.status}`) as Error & { status: number; body: unknown }
+    err.status = res.status
+    err.body = body
+    throw err
+  }
   return body
 }
 

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -154,7 +154,7 @@ export async function getProjeto(id: string): Promise<Projeto> {
   return mapProjeto(res.data)
 }
 
-export async function createProjeto(payload: ProjetoInput) {
+export async function createProjeto(payload: ProjetoInput & { skipBriefingEval?: boolean }) {
   const errs = validateProjetoInput(payload)
   if (errs.length) throw new Error(errs.join(' | '))
   const designerId = getCurrentUserId()
@@ -167,6 +167,7 @@ export async function createProjeto(payload: ProjetoInput) {
     prazo: payload.prazo ?? null,
     clienteId: payload.cliente_id,
     designerId,
+    ...(payload.skipBriefingEval ? { skipBriefingEval: true } : {}),
   })
   return mapProjeto(res.data)
 }


### PR DESCRIPTION
## O que muda

### `components/projetos/ProjetoModal.tsx` (reescrito)
- **Remove Supabase completamente**: boot usa `useAuth()` + `listClientes()`/`listDesigners()` REST
- **BriefingEvalPanel**: quando o servidor retorna 422 com `evalResult`, exibe painel inline com:
  - Score por dimensão (completude / clareza / acionabilidade) com barra visual e cor (verde/amarelo/vermelho)
  - Justificativa textual do avaliador por dimensão
  - Botão "Melhorar briefing" → volta ao step 0 para editar a descrição
  - Botão "Criar mesmo assim" → reenvia com `skipBriefingEval: true`

### `lib/api.ts`
- Erros de resposta não-OK agora carregam `.status` e `.body` para o caller poder distinguir 422 briefing de outros erros

### `lib/projects.ts`
- `createProjeto` aceita `skipBriefingEval?: boolean` e passa no body

### `app/(dashboard)/projetos/page.tsx`
- Remove `import { supabase }` — `onDelete` fazia contagem de artes/tarefas via Supabase; substituído por delete otimista com rollback via `reload()` em caso de erro do backend
- `onCreate` não exibe toast para erros 422 (deixa o modal tratar)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdRDDdiaAhDYXHupLTaDJE)_